### PR TITLE
Explicitly implement `PartialOrd` comparisons

### DIFF
--- a/bitint/src/types.rs
+++ b/bitint/src/types.rs
@@ -262,7 +262,31 @@ macro_rules! define_ubitint_type {
         impl PartialOrd for $self {
             #[inline(always)]
             fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                self.to_primitive().partial_cmp(&other.to_primitive())
+                Some(self.cmp(other))
+            }
+
+            // As of Rust 1.71, leveraging the default function impls can result
+            // in poor codegen. (Rather than compare the primitive, it computes
+            // the Ordering discriminant and compares with that instead.)
+
+            #[inline(always)]
+            fn lt(&self, other: &Self) -> bool {
+                self.to_primitive() < other.to_primitive()
+            }
+
+            #[inline(always)]
+            fn le(&self, other: &Self) -> bool {
+                self.to_primitive() <= other.to_primitive()
+            }
+
+            #[inline(always)]
+            fn gt(&self, other: &Self) -> bool {
+                self.to_primitive() > other.to_primitive()
+            }
+
+            #[inline(always)]
+            fn ge(&self, other: &Self) -> bool {
+                self.to_primitive() >= other.to_primitive()
             }
         }
 

--- a/bitint/tests/tests.rs
+++ b/bitint/tests/tests.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use bitint::prelude::*;
 
 #[bitint_literals]
@@ -14,6 +16,19 @@ fn test_display() {
     assert_eq!(format!("{}", 1_U1), "1");
     assert_eq!(format!("{}", 1234_U12), "1234");
     assert_eq!(format!("{}", 65535_U16), "65535");
+}
+
+#[bitint_literals]
+#[test]
+fn test_bit_cmp() {
+    assert_eq!(0b0100_U4.cmp(&0b0101_U4), Ordering::Less);
+    assert_eq!(0b1011_U4.cmp(&0b1011_U4), Ordering::Equal);
+    assert_eq!(0b1111_U4.cmp(&0b1110_U4), Ordering::Greater);
+    assert!(0b0010100_U7 <  0b1010100_U7);
+    assert!(0b0010111_U7 <= 0b0010111_U7);
+    assert!(0b1111111_U7 == 0b1111111_U7);
+    assert!(0b1011101_U7 >= 0b1011101_U7);
+    assert!(0b1010001_U7 >  0b1010000_U7);
 }
 
 #[bitint_literals]


### PR DESCRIPTION
Avoids bad codegen due to the default impls not optimizing beyond a `match`.