### PR TITLE
Don't check rustfmt in nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
-          components: clippy, miri, rust-src, rustfmt
-      - name: Check formatting
-        run: cargo +nightly fmt --check
+          components: clippy, miri, rust-src
       - name: Check Clippy lints
         run: cargo +nightly clippy --all-features -- --deny warnings
       - name: Run tests with overflow checks


### PR DESCRIPTION
The canonical formatting for this project is defined by stable rustfmt, though I need to pin that explicitly somewhere to have a coherent policy.